### PR TITLE
Rman 20190501

### DIFF
--- a/src/app/homepage/wallet-status/wallet-status.component.ts
+++ b/src/app/homepage/wallet-status/wallet-status.component.ts
@@ -97,7 +97,7 @@ export class WalletStatusComponent implements OnInit, OnDestroy {
     if (this.wallet.isEncrypted && setStaking) {
       command = [
         new RpcSend('walletpassphrase', [
-          this.stakingForm.value.stakingPassword,
+          'this.stakingForm.value.stakingPassword',
           999999999999999999,
           true
         ]),

--- a/src/app/homepage/wallet-status/wallet-status.component.ts
+++ b/src/app/homepage/wallet-status/wallet-status.component.ts
@@ -97,7 +97,7 @@ export class WalletStatusComponent implements OnInit, OnDestroy {
     if (this.wallet.isEncrypted && setStaking) {
       command = [
         new RpcSend('walletpassphrase', [
-          \'this.stakingForm.value.stakingPassword\',
+          this.stakingForm.value.stakingPassword,
           99999999,
           true
         ]),

--- a/src/app/homepage/wallet-status/wallet-status.component.ts
+++ b/src/app/homepage/wallet-status/wallet-status.component.ts
@@ -97,7 +97,7 @@ export class WalletStatusComponent implements OnInit, OnDestroy {
     if (this.wallet.isEncrypted && setStaking) {
       command = [
         new RpcSend('walletpassphrase', [
-          'this.stakingForm.value.stakingPassword',
+          this.stakingForm.value.stakingPassword,
           999999999999999999,
           true
         ]),

--- a/src/app/homepage/wallet-status/wallet-status.component.ts
+++ b/src/app/homepage/wallet-status/wallet-status.component.ts
@@ -97,8 +97,8 @@ export class WalletStatusComponent implements OnInit, OnDestroy {
     if (this.wallet.isEncrypted && setStaking) {
       command = [
         new RpcSend('walletpassphrase', [
-          this.stakingForm.value.stakingPassword,
-          999999999999999999,
+          \'this.stakingForm.value.stakingPassword\',
+          99999999,
           true
         ]),
         new RpcSend('staking', [setStaking])


### PR DESCRIPTION
Use seconds value equivalent to 1157 days for unlocking wallet for staking. I believe the previous value was too high and was preventing staking from being enabled.

    if (this.wallet.isEncrypted && setStaking) {
      command = [
        new RpcSend('walletpassphrase', [
          this.stakingForm.value.stakingPassword,
          99999999,
          true
        ]),